### PR TITLE
Added search for fresh libxml++*.so library

### DIFF
--- a/bulkbuild.sh
+++ b/bulkbuild.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
 
+LIBXMLNAME=$( find /usr/lib* -maxdepth 1 -type l,f -name libxml++-\*.so | head -n1 | sed 's@.so.*$@@' | xargs basename )
+LIBXMLOPTS=$( pkg-config --cflags --libs $LIBXMLNAME )
+
 # -Wno-deprecated-declarations prevents libxml++-2.6 warnings
 
 g++ -O3 -pipe -Isrc/libs/liblinefetch -Isrc/libs/libtplreader \
     -Wno-deprecated-declarations \
-    `pkg-config --cflags --libs libxml++-2.6` \
+    $LIBXMLOPTS \
     src/artlibgen/src/*.cc src/libs/liblinefetch/*.cc src/libs/libtplreader/*.cc \
     -o src/artlibgen/src/artlibgen
 
 g++ -O3 -pipe -Isrc/libs/liblinefetch -Isrc/libs/libtplreader \
     -Wno-deprecated-declarations \
-    `pkg-config --cflags --libs libxml++-2.6` \
+    $LIBXMLOPTS \
     src/artrepgen/*.cc src/libs/liblinefetch/*.cc src/libs/libtplreader/*.cc \
     -o src/artrepgen/artrepgen


### PR DESCRIPTION
old version: static name libxml++-2.6
new version: name libxml++.* should be found in /usr/lib* folders